### PR TITLE
fix: some bugs

### DIFF
--- a/src/components/about/BeyondCodeExpandedSection.tsx
+++ b/src/components/about/BeyondCodeExpandedSection.tsx
@@ -17,14 +17,14 @@ const BeyondCodeExpandedSection: React.FC = () => {
             iconClass: 'fas fa-brain',
             iconColorClass: 'text-yellow-400',
             title: 'Self-Development',
-            description: 'I love learning new things in various fields, whether it\'s science, mathematics, or new concepts in technology.',
+            description: 'I love learning new things in various fields, whether it&rsquo;s science, mathematics, or new concepts in technology.',
             delay: 200,
         },
         {
             iconClass: 'fas fa-music',
             iconColorClass: 'text-cyan-400',
             title: 'Music Enthusiast',
-            description: 'Exploring diverse genres and finding inspiration in melodies and rhythms. Music is a great companion for coding sessions.', // Новий опис
+            description: 'Exploring diverse genres and finding inspiration in melodies and rhythms. Music is a great companion for coding sessions.',
             delay: 300,
         },
         {
@@ -98,7 +98,7 @@ const BeyondCodeExpandedSection: React.FC = () => {
                     Beyond The Code
                 </h2>
                 <p ref={descriptionRef} className="section-description opacity-0" data-delay="100">
-                    Life isn't just about programming. Here's what inspires me and helps me grow.
+                    Life isn&rsquo;t just about programming. Here&rsquo;s what inspires me and helps me grow.
                 </p>
                 <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-8">
                     {hobbiesData.map((hobby, index) => (


### PR DESCRIPTION
This pull request makes minor updates to the text content in the `BeyondCodeExpandedSection` component to improve typographic consistency by replacing straight single quotes with HTML entities for apostrophes (`&rsquo;`).

Text content updates:

* Updated the `description` field for the "Self-Development" hobby to use `&rsquo;` for the apostrophe. (`src/components/about/BeyondCodeExpandedSection.tsx`, [src/components/about/BeyondCodeExpandedSection.tsxL20-R27](diffhunk://#diff-d085673bffb77536b3841ed11028a01cadcb770895f34fc233c0131802699753L20-R27))
* Updated the section description text to use `&rsquo;` for apostrophes in "isn't" and "Here's." (`src/components/about/BeyondCodeExpandedSection.tsx`, [src/components/about/BeyondCodeExpandedSection.tsxL101-R101](diffhunk://#diff-d085673bffb77536b3841ed11028a01cadcb770895f34fc233c0131802699753L101-R101))